### PR TITLE
FEATURE: Add chat mobile view

### DIFF
--- a/assets/javascripts/discourse/components/embeddable-chat-channel.gjs
+++ b/assets/javascripts/discourse/components/embeddable-chat-channel.gjs
@@ -115,7 +115,7 @@ export default class EmbedableChatChannel extends Component {
   }
 
   get isConferencePage() {
-    return Boolean(!this.topicModel);
+    return Boolean(!this.topicModel) && !this.args.inTopic;
   }
 
   @action
@@ -144,6 +144,11 @@ export default class EmbedableChatChannel extends Component {
 
   @action
   handleResize() {
+    // don't resize the chat if we are in a topic
+    if (this.args.inTopic) {
+      return;
+    }
+
     document.body.classList.remove("has-sidebar-page");
     document.body.classList.remove("docked");
 
@@ -174,7 +179,6 @@ export default class EmbedableChatChannel extends Component {
   <template>
     {{#if this.shouldRender}}
       {{#if this.isConferencePage}}
-
         <DButton
           @icon={{if
             this.isChatCollapsed

--- a/assets/javascripts/discourse/connectors/above-footer/embeddable-chat-channel.hbs
+++ b/assets/javascripts/discourse/connectors/above-footer/embeddable-chat-channel.hbs
@@ -1,3 +1,3 @@
-{{#unless this.site.isMobileDevice}}
+{{#unless this.site.mobileView}}
   <EmbeddableChatChannel />
 {{/unless}}

--- a/assets/javascripts/discourse/connectors/topic-above-footer-buttons/mobile-embeddable-chat-channel.gjs
+++ b/assets/javascripts/discourse/connectors/topic-above-footer-buttons/mobile-embeddable-chat-channel.gjs
@@ -1,0 +1,32 @@
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+import EmbedableChatChannel from "../../components/embeddable-chat-channel";
+import DButton from "discourse/components/d-button";
+import { tracked } from "@glimmer/tracking";
+import { and } from "truth-helpers";
+import { action } from "@ember/object";
+
+export default class MobileEmbedableChatChannel extends Component {
+  @service site;
+
+  @tracked showChat = true;
+
+  @action
+  toggleChat() {
+    this.showChat = !this.showChat;
+  }
+
+  <template>
+    {{#if this.site.mobileView}}
+      <DButton
+        @label={{"discourse_livestream.chat"}}
+        @action={{this.toggleChat}}
+        @icon={{if this.showChat "caret-down" "caret-up"}}
+        id="in-topic-livestream-chat-toggle"
+      />
+      {{#if this.showChat}}
+        <EmbedableChatChannel @inTopic={{true}} />
+      {{/if}}
+    {{/if}}
+  </template>
+}

--- a/assets/javascripts/discourse/connectors/topic-above-footer-buttons/mobile-embeddable-chat-channel.gjs
+++ b/assets/javascripts/discourse/connectors/topic-above-footer-buttons/mobile-embeddable-chat-channel.gjs
@@ -1,10 +1,9 @@
 import Component from "@glimmer/component";
-import { inject as service } from "@ember/service";
-import EmbedableChatChannel from "../../components/embeddable-chat-channel";
-import DButton from "discourse/components/d-button";
 import { tracked } from "@glimmer/tracking";
-import { and } from "truth-helpers";
 import { action } from "@ember/object";
+import { service } from "@ember/service";
+import DButton from "discourse/components/d-button";
+import EmbedableChatChannel from "../../components/embeddable-chat-channel";
 
 export default class MobileEmbedableChatChannel extends Component {
   @service site;

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -40,6 +40,7 @@ async function onAcceptInvite({ status, chatChannelsManager, topic }) {
 
 function overrideChat(api, container) {
   const siteSettings = container.lookup("service:site-settings");
+  const site = container.lookup("service:site");
   if (!siteSettings.enable_livestream_chat) {
     return;
   }
@@ -109,7 +110,9 @@ function overrideChat(api, container) {
       document.body.classList.remove("custom-chat-enabled");
       appEvents.trigger("chat:toggle-close");
     } else {
-      updateTopicStylesWithChatChannel(topic, store, currentUser);
+      if (!site.mobileView) {
+        updateTopicStylesWithChatChannel(topic, store, currentUser);
+      }
     }
   });
 }

--- a/assets/stylesheets/common/discourse-livestream.scss
+++ b/assets/stylesheets/common/discourse-livestream.scss
@@ -1073,3 +1073,13 @@ body.custom-chat-enabled {
     }
   }
 }
+
+#in-topic-livestream-chat-toggle {
+  width: 100%;
+}
+
+html.mobile-view body.tag-livestream #custom-chat-container {
+  max-height: 400px !important;
+  height: 400px !important;
+  margin-top: 1em;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -10,3 +10,4 @@ en:
       notifications:
         label: "Solved Notifications"
         dont_send_accepted_solution_notifications: "Don't send me a notitification PM to recommend similar topics to answer"
+      chat: "Livestream Chat"


### PR DESCRIPTION
<img width="425" alt="Screenshot 2024-05-07 at 9 49 55 AM" src="https://github.com/discourse/discourse-livestream/assets/50783505/a7ff96c0-7a3f-4ff2-b03b-2f5382c95df7">

- Fix mobile chat view
- Don't resize on mobile
- Add `inTopic` argument to `EmbeddableChatChannel` to avoid resizing and manipulating of dom when in a topic setting