### PR TITLE
FIX: Bad sidebar state

### DIFF
--- a/assets/javascripts/discourse/components/embeddable-chat-channel.gjs
+++ b/assets/javascripts/discourse/components/embeddable-chat-channel.gjs
@@ -19,6 +19,7 @@ export default class EmbedableChatChannel extends Component {
   @service conference;
   @service chatStateManager;
   @service router;
+  @service sidebarState;
   @controller("topic") topicController;
 
   @tracked showConferenceChannelsList = false;
@@ -63,14 +64,6 @@ export default class EmbedableChatChannel extends Component {
 
     if (!this.shouldRender) {
       this.embeddableChat.activeChannel = null;
-      if (!this.args.inTopic) {
-        const parentElement = document.querySelector(".discourse-root");
-        const sidebar = document.querySelector(".drop-down-mode.d-header-wrap");
-        parentElement.prepend(sidebar);
-        document.body.classList.add("has-sidebar-page");
-        document.body.classList.add("docked");
-      }
-      return;
     }
   }
 
@@ -152,9 +145,6 @@ export default class EmbedableChatChannel extends Component {
     if (this.args.inTopic) {
       return;
     }
-
-    document.body.classList.remove("has-sidebar-page");
-    document.body.classList.remove("docked");
 
     const chatDrawerElement = document.querySelector("#custom-chat-container");
 

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -112,8 +112,7 @@ function overrideChat(api, container) {
       appEvents.trigger("chat:toggle-close");
     } else {
       updateTopicStylesWithChatChannel(topic, store, currentUser, site);
-      const sidebar = document.querySelector("body.has-sidebar-page");
-      if (sidebar) {
+      if (document.body.classList.contains("has-sidebar-page")) {
         applicationController.toggleSidebar();
       }
     }

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -53,6 +53,7 @@ function overrideChat(api, container) {
   const appEvents = container.lookup("service:appEvents");
   let topic = container.lookup("controller:topic");
   const currentUser = api.getCurrentUser();
+  const applicationController = container.lookup("controller:application");
 
   if (!currentUser || !chatService.userCanChat) {
     return;
@@ -111,6 +112,10 @@ function overrideChat(api, container) {
       appEvents.trigger("chat:toggle-close");
     } else {
       updateTopicStylesWithChatChannel(topic, store, currentUser, site);
+      const sidebar = document.querySelector("body.has-sidebar-page");
+      if (sidebar) {
+        applicationController.toggleSidebar();
+      }
     }
   });
 }


### PR DESCRIPTION
Rather than trying to hide / show the sidebar with css it is better to lean on the already existing `toggleSidebar` action from core to show / hide it. 

This cleans up bad states that could happen when navigating between livestream topics and regular topics.