### PR TITLE
DEV: Scroll to top of page on livestream topic loaded

### DIFF
--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -39,7 +39,7 @@ async function onAcceptInvite({ status, chatChannelsManager, topic }) {
   }
 }
 
-export function overrideChat(api, container) {
+function overrideChat(api, container) {
   const siteSettings = container.lookup("service:site-settings");
   const site = container.lookup("service:site");
   if (!siteSettings.enable_livestream_chat) {
@@ -128,7 +128,7 @@ export function overrideChat(api, container) {
           block: "start",
           inline: "start",
         });
-      }, 400);
+      }, 500);
     }
   });
 }

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -1,3 +1,4 @@
+import { later } from "@ember/runloop";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
 function showCustomBBCode(isGoing = false) {
@@ -38,7 +39,7 @@ async function onAcceptInvite({ status, chatChannelsManager, topic }) {
   }
 }
 
-function overrideChat(api, container) {
+export function overrideChat(api, container) {
   const siteSettings = container.lookup("service:site-settings");
   const site = container.lookup("service:site");
   if (!siteSettings.enable_livestream_chat) {
@@ -115,6 +116,19 @@ function overrideChat(api, container) {
       if (document.body.classList.contains("has-sidebar-page")) {
         applicationController.toggleSidebar();
       }
+
+      // Chat scrolls to the bottom of the page when the chat channel is loaded
+      // this is required for the chat message positioning to be correct.
+      // We need to scroll to the top of the page after the chat channel is loaded
+      // to avoid the page being rendered and the viewport being scrolled to the bottom.
+      // This is not an ideal solution, but it's the best we can do for now
+      later(() => {
+        document.documentElement.scrollIntoView({
+          behavior: "smooth",
+          block: "start",
+          inline: "start",
+        });
+      }, 400);
     }
   });
 }


### PR DESCRIPTION
Chat scrolls to the bottom of the page when the chat channel is loaded. This is required for the chat message positioning to be correct. We need to scroll to the top of the page after the chat channel is loaded to avoid the page being rendered and the viewport being scrolled to the bottom.
      
This is not an ideal solution, but it's the best we can do for now

# Desktop
https://github.com/discourse/discourse-livestream/assets/50783505/44250754-64e3-44b5-9976-6131f6779a4e

# Mobile
https://github.com/discourse/discourse-livestream/assets/50783505/5f22674c-0854-4adf-a5e3-0c45f69f8196

