### PR TITLE
UX: Update mobile styling and header icons

### DIFF
--- a/assets/javascripts/discourse/components/mobile-livestream-chat-icon.gjs
+++ b/assets/javascripts/discourse/components/mobile-livestream-chat-icon.gjs
@@ -15,7 +15,7 @@ export default class MobileLivestreamChatIcon extends Component {
   <template>
     <li class="header-dropdown-toggle livestream-header-icon">
       <DButton
-        @icon="d-chat"
+        @icon="comments"
         class="icon btn-flat"
         tabindex="0"
         @action={{this.openLivestreamChat}}

--- a/assets/javascripts/discourse/components/modal/mobile-embeddable-chat-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/mobile-embeddable-chat-modal.gjs
@@ -2,7 +2,6 @@ import Component from "@glimmer/component";
 import { inject as controller } from "@ember/controller";
 import { inject as service } from "@ember/service";
 import DModal from "discourse/components/d-modal";
-import i18n from "discourse-common/helpers/i18n";
 import EmbeddableChatChannel from "../embeddable-chat-channel";
 
 export default class MobileEmbeddableChatModal extends Component {
@@ -17,7 +16,7 @@ export default class MobileEmbeddableChatModal extends Component {
     <DModal
       @closeModal={{@closeModal}}
       class="livestream-chat-modal"
-      @title={{i18n "discourse_livestream.chat.title"}}
+      @hideHeader={{true}}
     >
       <:body>
         {{#if this.shouldRender}}

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -58,7 +58,9 @@ function overrideChat(api, container) {
   });
 
   if (site.mobileView) {
-    api.headerIcons.add("livestream", MobileLivestreamChatIcon);
+    api.headerIcons.add("livestream", MobileLivestreamChatIcon, {
+      before: "chat",
+    });
   }
 
   api.onPageChange((url) => {

--- a/assets/stylesheets/mobile/base-mobile.scss
+++ b/assets/stylesheets/mobile/base-mobile.scss
@@ -6,34 +6,37 @@ body.tag-livestream.chat-enabled {
       &::after {
         content: "";
         position: absolute;
-        top: 8px;
-        right: 8px;
-        width: 10px;
-        height: 10px;
+        top: 9px;
+        right: 16px;
+        width: 8px;
+        height: 8px;
         border-radius: 50%;
-        background-color: rgba(255, 0, 0, 0.874);
+        background-color: rgb(255, 0, 0);
         animation: pulse-circle 3s infinite;
       }
 
       @keyframes pulse-circle {
         0% {
           transform: scale(1);
-          background-color: rgba(255, 0, 0, 0.6);
+          background-color: rgba(255, 0, 0, 0.901);
         }
         50% {
-          transform: scale(1.5);
-          background-color: rgba(255, 0, 0, 0.3);
+          transform: scale(1.3);
+          background-color: rgba(255, 0, 0, 0.762);
         }
         100% {
           transform: scale(1);
-          background-color: rgba(255, 0, 0, 0.6);
+          background-color: rgba(255, 0, 0, 0.902);
         }
       }
     }
+  }
 
-    // hide the default chat icon in favor of the livestream icon
-    .chat-header-icon {
-      display: none;
+  // don't blur the background when the livestream chat modal is open
+  .livestream-chat-modal {
+    & ~ .d-modal__backdrop {
+      background-color: unset;
+      animation: none;
     }
   }
 
@@ -41,6 +44,7 @@ body.tag-livestream.chat-enabled {
     .d-modal__body {
       padding: 1em 0.4em 1em 0.4em;
     }
+
     #custom-chat-container {
       width: 100%;
       height: 400px !important;

--- a/assets/stylesheets/mobile/base-mobile.scss
+++ b/assets/stylesheets/mobile/base-mobile.scss
@@ -18,15 +18,15 @@ body.tag-livestream.chat-enabled {
       @keyframes pulse-circle {
         0% {
           transform: scale(1);
-          background-color: rgba(255, 0, 0, 0.901);
+          background-color: rgba(255, 0, 0, 0.9);
         }
         50% {
           transform: scale(1.3);
-          background-color: rgba(255, 0, 0, 0.762);
+          background-color: rgba(255, 0, 0, 0.75);
         }
         100% {
           transform: scale(1);
-          background-color: rgba(255, 0, 0, 0.902);
+          background-color: rgba(255, 0, 0, 0.9);
         }
       }
     }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -2,7 +2,6 @@ en:
   js:
     discourse_livestream:
       chat:
-        title: "Livestream Chat"
         going: "Click Going"
         join_channel_header: "🌟 Join the Buzz! 🌟"
         join_channel_message: "Confirm your attendance and unlock our event chat. Dive into discussions, share your excitement, and connect with fellow attendees!"

--- a/spec/system/mobile_topic_livestream_authenticated_spec.rb
+++ b/spec/system/mobile_topic_livestream_authenticated_spec.rb
@@ -18,15 +18,11 @@ describe "Discourse Livestream - Topic Livestream - Mobile - Authenticated",
   context "when in a topic view" do
     it "does not display livestream chat icon on regular topics" do
       topic_livestream.create_regular_topic(composer, topic_page)
-
-      expect(topic_page).to have_css(".chat-header-icon")
       expect(topic_page).not_to have_css(".livestream-header-icon")
     end
 
     it "displays the livestream chat icon on livestream topics" do
       topic_livestream.create_livestream_topic(composer, topic_page, livestream_tag)
-
-      expect(topic_page).not_to have_css(".chat-header-icon")
       expect(topic_page).to have_css(".livestream-header-icon")
     end
 


### PR DESCRIPTION
- Don't hide chat icon when viewing a livestream topic on mobile
- Add a livestream chat icon when viewing a livestream topic on mobile
- Fix sizing and emphasis of red pulse
- Remove modal header
- Remove modal title

# Chat Open

<img width="400" alt="Screenshot 2024-05-30 at 3 44 09 PM" src="https://github.com/discourse/discourse-livestream/assets/50783505/ceae9f3e-ee4e-4a0c-996f-ea33d4878409">

# Chat Closed

<img width="410" alt="Screenshot 2024-05-30 at 3 41 49 PM" src="https://github.com/discourse/discourse-livestream/assets/50783505/df856ee7-4c3a-4606-91f7-980e16085d04">
