### PR TITLE
UX: Fix margin and padding on desktop

### DIFF
--- a/assets/stylesheets/desktop/base-desktop.scss
+++ b/assets/stylesheets/desktop/base-desktop.scss
@@ -11,6 +11,7 @@ body.tag-livestream.chat-enabled {
       "sidebar content livestream"
       "sidebar below-content livestream";
     margin: 0;
+    padding-right: 0;
     max-width: 100%;
   }
 
@@ -27,5 +28,6 @@ body.tag-livestream.chat-enabled {
     --1dvh: 1vh;
     align-self: start;
     overflow-y: auto;
+    margin-left: 1em;
   }
 }


### PR DESCRIPTION
- Have chat container be positioned against the right side of the screen
- Add margin to the left side of the chat container

![image](https://github.com/discourse/discourse-livestream/assets/50783505/d3cd1eb9-e95a-4169-84d5-60d4db1b7454)
