### PR TITLE
FIX: Don't show 404 when RSVPing to a calendar event topic without accompanying chat channel

### DIFF
--- a/about.json
+++ b/about.json
@@ -1,8 +1,5 @@
 {
   "tests": {
-    "requiredPlugins": [
-      "https://github.com/discourse/discourse-solved",
-      "https://github.com/discourse/discourse-calendar"
-    ]
+    "requiredPlugins": ["https://github.com/discourse/discourse-calendar"]
   }
 }

--- a/about.json
+++ b/about.json
@@ -1,5 +1,8 @@
 {
   "tests": {
-    "requiredPlugins": ["https://github.com/discourse/discourse-solved"]
+    "requiredPlugins": [
+      "https://github.com/discourse/discourse-solved",
+      "https://github.com/discourse/discourse-calendar"
+    ]
   }
 }

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -15,23 +15,23 @@ function showCustomBBCode(isGoing = false) {
 
 async function onAcceptInvite({ status, chatChannelsManager, topic }) {
   if (status === "going") {
-    showCustomBBCode(true);
-    document.body.classList.add("confirmed-event-assistance");
     if (topic.model.chat_channel_id != null) {
       const channel = await chatChannelsManager.find(
         topic.model.chat_channel_id
       );
       chatChannelsManager.follow(channel);
     }
+    showCustomBBCode(true);
+    document.body.classList.add("confirmed-event-assistance");
   } else if (status !== "going") {
-    showCustomBBCode(false);
-    document.body.classList.remove("confirmed-event-assistance");
     if (topic.model.chat_channel_id != null) {
       const channel = await chatChannelsManager.find(
         topic.model.chat_channel_id
       );
       chatChannelsManager.unfollow(channel);
     }
+    showCustomBBCode(false);
+    document.body.classList.remove("confirmed-event-assistance");
   }
 }
 

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -16,14 +16,22 @@ function showCustomBBCode(isGoing = false) {
 async function onAcceptInvite({ status, chatChannelsManager, topic }) {
   if (status === "going") {
     showCustomBBCode(true);
-    const channel = await chatChannelsManager.find(topic.model.chat_channel_id);
-    chatChannelsManager.follow(channel);
     document.body.classList.add("confirmed-event-assistance");
+    if (topic.model.chat_channel_id != null) {
+      const channel = await chatChannelsManager.find(
+        topic.model.chat_channel_id
+      );
+      chatChannelsManager.follow(channel);
+    }
   } else if (status !== "going") {
     showCustomBBCode(false);
-    const channel = await chatChannelsManager.find(topic.model.chat_channel_id);
-    chatChannelsManager.unfollow(channel);
     document.body.classList.remove("confirmed-event-assistance");
+    if (topic.model.chat_channel_id != null) {
+      const channel = await chatChannelsManager.find(
+        topic.model.chat_channel_id
+      );
+      chatChannelsManager.unfollow(channel);
+    }
   }
 }
 

--- a/spec/system/livestream_calendar_event_spec.rb
+++ b/spec/system/livestream_calendar_event_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+describe "Discourse Livestream - Topic Livestream with events - Authenticated", type: :system do
+  fab!(:group)
+  fab!(:current_user) { Fabricate(:user, trust_level: 1, groups: [group]) }
+  fab!(:category)
+  fab!(:livestream_tag) { Fabricate(:tag, name: "livestream") }
+  let(:topic_page) { PageObjects::Pages::Topic.new }
+  let(:composer) { PageObjects::Components::Composer.new }
+  let(:topic_livestream) { PageObjects::Pages::TopicLivestream.new }
+
+  before do
+    SiteSetting.discourse_livestream_enabled = true
+    SiteSetting.calendar_enabled = true
+    SiteSetting.discourse_post_event_enabled = true
+    SiteSetting.discourse_post_event_allowed_on_groups = group.id
+    sign_in(current_user)
+  end
+
+  context "when in a event topic view" do
+    it "clicks going to join the chat channel for livestream topics" do
+      topic_livestream.create_livestream_event_topic(composer, topic_page, livestream_tag)
+
+      find(".going-button", wait: 25).click
+      expect(topic_page).to have_css(".confirmed-event-assistance", wait: 25)
+
+      find(".not-going-button").click
+      expect(topic_page).not_to have_css(".confirmed-event-assistance", wait: 25)
+    end
+
+    it "clicks going to join the chat channel for livestream topics" do
+      topic_livestream.create_normal_event_topic(composer, topic_page)
+
+      find(".going-button", wait: 25).click
+      expect(topic_page).to have_css(".confirmed-event-assistance", wait: 25)
+
+      find(".not-going-button").click
+      expect(topic_page).not_to have_css(".confirmed-event-assistance", wait: 25)
+    end
+  end
+end

--- a/spec/system/page_objects/discourse_livestream/topic_livestream.rb
+++ b/spec/system/page_objects/discourse_livestream/topic_livestream.rb
@@ -23,6 +23,35 @@ module PageObjects
         composer.fill_content("The content for my regular topic")
         composer.create
       end
+
+      def create_livestream_event_topic(composer, topic_page, tag)
+        visit("/latest")
+        topic_page.open_new_topic
+
+        composer.fill_title("Creating a livestream event topic")
+        tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
+        tag_chooser.expand
+        tag_chooser.select_row_by_name(tag.name)
+        tomorrow = (Time.zone.now + 1.day).strftime("%Y-%m-%d")
+        composer.fill_content <<~MD
+          [event start="#{tomorrow} 13:37" status="public"]
+          [/event]
+        MD
+        composer.create
+      end
+
+      def create_normal_event_topic(composer, topic_page)
+        visit("/latest")
+        topic_page.open_new_topic
+
+        composer.fill_title("Creating a normal event topic")
+        tomorrow = (Time.zone.now + 1.day).strftime("%Y-%m-%d")
+        composer.fill_content <<~MD
+          [event start="#{tomorrow} 13:37" status="public"]
+          [/event]
+        MD
+        composer.create
+      end
     end
   end
 end


### PR DESCRIPTION
In `topic_view` serializer, only topics that meet the tag containing `livestream` will have corresponding channel. The `chat_channel_id` of other topics will be `null`.

```ruby
    add_to_serializer(:topic_view, :chat_channel_id) do
      return nil if object.topic.topic_chat_channel.blank?
      object.topic.topic_chat_channel.chat_channel_id
    end
```

```ruby
  def self.handle_topic_chat_channel_creation(topic)
    return if topic.category.blank?
    return if DiscourseLivestream::TopicChatChannel.exists?(topic_id: topic.id)
    return if topic.tags.blank? || topic.tags.none? { |tag| tag.name == "livestream" }
```

In the original code, there is no handling of null cases, which will result in trying to obtain information of null channel and throwing 404.

This commit determines the case where `chat_channel_id` is `null`

before:

![image](https://github.com/user-attachments/assets/847c95f8-e6d4-44d5-a144-6e41a31428c9)


after:

(error be fixed)

related meta topic: https://meta.discourse.org/t/not-found-when-rsvping-to-event/315416