### PR TITLE
FIX: Show livestream join message only for topics with livestream chat

### DIFF
--- a/assets/javascripts/discourse/connectors/chat-join-channel-button/join-channel-message.gjs
+++ b/assets/javascripts/discourse/connectors/chat-join-channel-button/join-channel-message.gjs
@@ -1,12 +1,42 @@
 import i18n from "discourse-common/helpers/i18n";
+import DButton from "discourse/components/d-button";
+import concatClass from "discourse/helpers/concat-class";
+import { inject as controller } from "@ember/controller";
+import Component from "@glimmer/component";
+import { inject as service } from "@ember/service";
+import LIVESTREAM_TAG_NAME from "../../services/embeddable-chat";
 
-const JoinChannelMessage = <template>
-  <h2>
-    {{i18n "discourse_livestream.chat.join_channel_header"}}
-  </h2>
-  <p>
-    {{i18n "discourse_livestream.chat.join_channel_message"}}
-  </p>
-</template>;
+export default class JoinChannelMessage extends Component {
+  @controller("topic") topicController;
+  @service embeddableChat;
 
-export default JoinChannelMessage;
+  get shouldRenderJoinText() {
+    const topic = this.topicController?.model;
+    return (
+      topic?.chat_channel_id && this.embeddableChat.topicHasLivestreamTag(topic)
+    );
+  }
+
+  <template>
+    {{#if this.shouldRenderJoinText}}
+      <h2>
+        {{i18n "discourse_livestream.chat.join_channel_header"}}
+      </h2>
+      <p>
+        {{i18n "discourse_livestream.chat.join_channel_message"}}
+      </p>
+    {{else}}
+      <DButton
+        @action={{@outletArgs.onJoinChannel}}
+        @translatedLabel={{@outletArgs.label}}
+        @translatedTitle={{@outletArgs.options.joinTitle}}
+        @icon={{@outletArgs.options.joinIcon}}
+        @disabled={{@outletArgs.isLoading}}
+        class={{concatClass
+          "toggle-channel-membership-button -join"
+          @outletArgs.options.joinClass
+        }}
+      />
+    {{/if}}
+  </template>
+}

--- a/assets/javascripts/discourse/connectors/chat-join-channel-button/join-channel-message.gjs
+++ b/assets/javascripts/discourse/connectors/chat-join-channel-button/join-channel-message.gjs
@@ -1,14 +1,13 @@
-import i18n from "discourse-common/helpers/i18n";
+import Component from "@glimmer/component";
+import { inject as controller } from "@ember/controller";
+import { inject as service } from "@ember/service";
 import DButton from "discourse/components/d-button";
 import concatClass from "discourse/helpers/concat-class";
-import { inject as controller } from "@ember/controller";
-import Component from "@glimmer/component";
-import { inject as service } from "@ember/service";
-import LIVESTREAM_TAG_NAME from "../../services/embeddable-chat";
+import i18n from "discourse-common/helpers/i18n";
 
 export default class JoinChannelMessage extends Component {
-  @controller("topic") topicController;
   @service embeddableChat;
+  @controller("topic") topicController;
 
   get shouldRenderJoinText() {
     const topic = this.topicController?.model;

--- a/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -1,6 +1,8 @@
 import { inject as service } from "@ember/service";
 import Chat from "discourse/plugins/chat/discourse/services/chat";
 
+export const LIVESTREAM_TAG_NAME = "livestream";
+
 export default class EmbeddableChat extends Chat {
   @service siteSettings;
   @service site;
@@ -29,6 +31,10 @@ export default class EmbeddableChat extends Chat {
     }
 
     return false;
+  }
+
+  topicHasLivestreamTag(topic) {
+    return topic?.tags?.some?.((tag) => tag === LIVESTREAM_TAG_NAME) || false;
   }
 
   get chatChannelId() {


### PR DESCRIPTION
This PR fixes an issue where the join button wasn't displaying for chats that were not part of a livestream. 
Now, the livestream join message only shows on topics with an associated livestream chat.

![image](https://github.com/user-attachments/assets/761625c5-3ccb-4839-bb25-36a1d2dae061)
