### PR TITLE
DEV: Fix mismatched column types

### DIFF
--- a/db/migrate/20241014111100_alter_livestream_ids_to_bigint.rb
+++ b/db/migrate/20241014111100_alter_livestream_ids_to_bigint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AlterLivestreamIdsToBigint < ActiveRecord::Migration[7.1]
+  def up
+    change_column :livestream_topic_chat_channels, :chat_channel_id, :bigint
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
The primary key is usually a bigint column, but the foreign key columns are usually of integer type. This can lead to issues when joining these columns due to mismatched types and different value ranges.