### PR TITLE
UX: Scope livestream styles to livestream topics

### DIFF
--- a/assets/stylesheets/desktop/base-desktop.scss
+++ b/assets/stylesheets/desktop/base-desktop.scss
@@ -1,4 +1,4 @@
-body.tag-livestream.chat-enabled {
+body.tag-livestream.chat-enabled.archetype-regular {
   // we need to fullscreen the header icons to match the chat panel
   // being on the right side of the screen
   .d-header-wrap .wrap {


### PR DESCRIPTION
Currently, livestream-tagged topics have special styling but is applied to the topic list page as well.

### Before

<img width="600" alt="Screenshot 2025-03-07 at 5 42 26 PM" src="https://github.com/user-attachments/assets/eb7b6f1d-7b7e-49ba-b58a-e721b2dce9a7" />

### After

This PR scopes the styles to topics only.

<img width="600" alt="Screenshot 2025-03-07 at 5 44 18 PM" src="https://github.com/user-attachments/assets/6adb9b55-335b-4222-8f04-cee1a1d32f2f" />
<img width="600" alt="Screenshot 2025-03-07 at 5 44 36 PM" src="https://github.com/user-attachments/assets/fc58349a-969b-40b6-85cb-0e98f092f8f6" />
