### PR TITLE
FIX: broken specs

### DIFF
--- a/spec/system/desktop_topic_livestream_authenticated_spec.rb
+++ b/spec/system/desktop_topic_livestream_authenticated_spec.rb
@@ -17,14 +17,14 @@ describe "Discourse Livestream - Topic Livestream - Desktop - Authenticated", ty
     it "creates a chat channel for livestream topics" do
       topic_livestream.create_livestream_topic(composer, topic_page, livestream_tag)
 
-      expect(topic_page).to have_css("#custom-chat-container", wait: 25)
+      expect(topic_page).to have_css("#custom-chat-container")
       expect(topic_page).to have_css("#custom-chat-container .chat-channel-preview-card")
     end
 
     it "does not create a chat channel for regular topics" do
       topic_livestream.create_regular_topic(composer, topic_page)
 
-      expect(topic_page).not_to have_css("#custom-chat-container", wait: 25)
+      expect(topic_page).not_to have_css("#custom-chat-container")
     end
   end
 end

--- a/spec/system/page_objects/discourse_livestream/topic_livestream.rb
+++ b/spec/system/page_objects/discourse_livestream/topic_livestream.rb
@@ -11,6 +11,8 @@ module PageObjects
         tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
         tag_chooser.expand
         tag_chooser.select_row_by_name(tag.name)
+        tag_chooser.collapse
+
         composer.fill_content("The content for my livestream topic")
         composer.create
       end
@@ -32,6 +34,8 @@ module PageObjects
         tag_chooser = PageObjects::Components::SelectKit.new(".composer-fields .mini-tag-chooser")
         tag_chooser.expand
         tag_chooser.select_row_by_name(tag.name)
+        tag_chooser.collapse
+
         tomorrow = (Time.zone.now + 1.day).strftime("%Y-%m-%d")
         composer.fill_content <<~MD
           [event start="#{tomorrow} 13:37" status="public"]


### PR DESCRIPTION
Collapsing is not necessary but it ensures select-kit is not going to grab focus if we type too fast. This was particularly flaky since playwright.