### PR TITLE
UX: fix topic map positioning when user marks as "Going"

### DIFF
--- a/assets/stylesheets/common/base-common.scss
+++ b/assets/stylesheets/common/base-common.scss
@@ -14,7 +14,6 @@ body.chat-enabled.tag-livestream.confirmed-event-assistance {
   }
 
   .container.posts {
-    display: block;
     width: 100%;
 
     .topic-body {


### PR DESCRIPTION
Before:

<img width="1710" alt="Screenshot 2025-06-12 at 4 51 52 PM" src="https://github.com/user-attachments/assets/0b337b86-03bf-4dac-bc55-69f9f7f23922" />

After:

<img width="1710" alt="Screenshot 2025-06-12 at 4 51 30 PM" src="https://github.com/user-attachments/assets/5ca409cd-0645-4222-bae6-8032661d01e3" />
