### PR TITLE
UX: switch to chat modal based on viewport width

### DIFF
--- a/assets/javascripts/discourse/components/modal/mobile-embeddable-chat-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/mobile-embeddable-chat-modal.gjs
@@ -1,12 +1,20 @@
 import Component from "@glimmer/component";
 import { inject as controller } from "@ember/controller";
+import didUpdate from "@ember/render-modifiers/modifiers/did-update";
 import { service } from "@ember/service";
 import DModal from "discourse/components/d-modal";
 import EmbeddableChatChannel from "../embeddable-chat-channel";
 
 export default class MobileEmbeddableChatModal extends Component {
   @service embeddableChat;
+  @service capabilities;
   @controller("topic") topicController;
+
+  checkAndCloseModal = () => {
+    if (this.capabilities.viewport.lg) {
+      this.args.closeModal();
+    }
+  };
 
   get shouldRender() {
     return this.embeddableChat.canRenderChatChannel(this.topicController, true);
@@ -17,6 +25,7 @@ export default class MobileEmbeddableChatModal extends Component {
       @closeModal={{@closeModal}}
       class="livestream-chat-modal"
       @hideHeader={{true}}
+      {{didUpdate this.checkAndCloseModal this.capabilities.viewport.lg}}
     >
       <:body>
         {{#if this.shouldRender}}

--- a/assets/javascripts/discourse/components/responsive-livestream-chat-icon.gjs
+++ b/assets/javascripts/discourse/components/responsive-livestream-chat-icon.gjs
@@ -1,0 +1,17 @@
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+import MobileLivestreamChatIcon from "./mobile-livestream-chat-icon";
+
+export default class ResponsiveLivestreamChatIcon extends Component {
+  @service capabilities;
+
+  get shouldShow() {
+    return !this.capabilities.viewport.lg;
+  }
+
+  <template>
+    {{#if this.shouldShow}}
+      <MobileLivestreamChatIcon />
+    {{/if}}
+  </template>
+}

--- a/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
+++ b/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
@@ -6,16 +6,17 @@ import EmbeddableChatChannel from "../../components/embeddable-chat-channel";
 export default class EmbedableChatChannelConnector extends Component {
   @service embeddableChat;
   @service siteSettings;
-  @service site;
+  @service capabilities;
   @controller("topic") topicController;
 
   get shouldRender() {
-    const mobileView =
-      !this.siteSettings.enable_modal_chat_on_mobile && this.site.mobileView;
+    const mobileViewport =
+      !this.siteSettings.enable_modal_chat_on_mobile &&
+      !this.capabilities.viewport.lg;
 
     return this.embeddableChat.canRenderChatChannel(
       this.topicController,
-      mobileView
+      mobileViewport
     );
   }
 

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -1,5 +1,5 @@
 import { withPluginApi } from "discourse/lib/plugin-api";
-import MobileLivestreamChatIcon from "../components/mobile-livestream-chat-icon";
+import ResponsiveLivestreamChatIcon from "../components/responsive-livestream-chat-icon";
 
 function showCustomBBCode(isGoing = false) {
   // show the content within the [preview] tag if the user is not going to the event
@@ -28,7 +28,6 @@ function overrideChat(api, container) {
   const currentUser = api.getCurrentUser();
   const chatService = container.lookup("service:chat");
   const appEvents = container.lookup("service:appEvents");
-  const site = container.lookup("service:site");
 
   if (!currentUser || !siteSettings.chat_enabled || !chatService.userCanChat) {
     return;
@@ -48,11 +47,9 @@ function overrideChat(api, container) {
     });
   });
 
-  if (site.mobileView) {
-    api.headerIcons.add("livestream", MobileLivestreamChatIcon, {
-      before: "chat",
-    });
-  }
+  api.headerIcons.add("livestream", ResponsiveLivestreamChatIcon, {
+    before: "chat",
+  });
 
   api.onPageChange((url) => {
     const store = container.lookup("service:store");
@@ -103,7 +100,7 @@ async function updateEventStylesByStatus(topic, store, currentUser) {
 export default {
   name: "discourse-livestream-chat-sidebar",
   initialize(container) {
-    withPluginApi("1.8.0", (api) => {
+    withPluginApi((api) => {
       overrideChat(api, container);
     });
   },

--- a/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -10,13 +10,14 @@ export default class EmbeddableChat extends Chat {
   @service site;
   @service router;
   @service currentUser;
+  @service capabilities;
 
   @tracked isMobileChatVisible = false;
 
   canRenderChatChannel(topicController, mobileViewAllowed = false) {
     this.topicController = topicController;
     if (
-      this.site.mobileView === mobileViewAllowed &&
+      this.isMobileViewport === mobileViewAllowed &&
       this.siteSettings.chat_enabled &&
       this.currentUser &&
       this.userCanChat
@@ -48,8 +49,12 @@ export default class EmbeddableChat extends Chat {
 
   get isMobileModal() {
     return (
-      this.siteSettings.enable_modal_chat_on_mobile && this.site.mobileView
+      this.siteSettings.enable_modal_chat_on_mobile && this.isMobileViewport
     );
+  }
+
+  get isMobileViewport() {
+    return !this.capabilities.viewport.lg;
   }
 
   get chatChannelId() {

--- a/assets/stylesheets/common/base-common.scss
+++ b/assets/stylesheets/common/base-common.scss
@@ -32,3 +32,9 @@ body.chat-enabled.tag-livestream .chat-channel-preview-card {
     display: none;
   }
 }
+
+.livestream-chat-modal {
+  .chat-drawer {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
This swaps out `this.site.mobileView` with viewport width detection using the capabilities service. Doing this means that smaller screens and browser widths don't get a squished experience. 


Before:
<img width="1574" height="1724" alt="image" src="https://github.com/user-attachments/assets/8e14d2c7-6a32-4eab-b1c3-dde16810c158" />



After (switches to header button for chat trigger): 
<img width="2014" height="1722" alt="image" src="https://github.com/user-attachments/assets/842de9e2-f35a-4876-905c-50ca52da06b5" />

<img width="1606" height="1720" alt="image" src="https://github.com/user-attachments/assets/4d4b44f0-1709-403b-87eb-a1b7a0a1780c" />

