### PR TITLE
FIX: only show livestream chat button if channel is present

### DIFF
--- a/assets/javascripts/discourse/components/responsive-livestream-chat-icon.gjs
+++ b/assets/javascripts/discourse/components/responsive-livestream-chat-icon.gjs
@@ -1,12 +1,17 @@
 import Component from "@glimmer/component";
+import { inject as controller } from "@ember/controller";
 import { service } from "@ember/service";
 import MobileLivestreamChatIcon from "./mobile-livestream-chat-icon";
 
 export default class ResponsiveLivestreamChatIcon extends Component {
   @service capabilities;
+  @controller("topic") topicController;
 
   get shouldShow() {
-    return !this.capabilities.viewport.lg;
+    return (
+      !this.capabilities.viewport.lg &&
+      this.topicController?.model?.chat_channel_id
+    );
   }
 
   <template>

--- a/test/javascripts/responsive-chat-icon-test.gjs
+++ b/test/javascripts/responsive-chat-icon-test.gjs
@@ -1,0 +1,56 @@
+import { render } from "@ember/test-helpers";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+import ResponsiveLivestreamChatIcon from "discourse/plugins/discourse-livestream/discourse/components/responsive-livestream-chat-icon";
+
+module(
+  "Integration | Component | ResponsiveLivestreamChatIcon",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("it shows the icon when viewport is small and topic has chat channel", async function (assert) {
+      const capabilities = this.owner.lookup("service:capabilities");
+      const topicController = this.owner.lookup("controller:topic");
+
+      capabilities.viewport = { lg: false };
+
+      topicController.model = { chat_channel_id: 123 };
+
+      await render(<template><ResponsiveLivestreamChatIcon /></template>);
+
+      assert
+        .dom(".livestream-header-icon")
+        .exists("Icon shows on mobile with chat channel");
+    });
+
+    test("it hides the icon when viewport is large", async function (assert) {
+      const capabilities = this.owner.lookup("service:capabilities");
+      const topicController = this.owner.lookup("controller:topic");
+
+      capabilities.viewport = { lg: true };
+
+      topicController.model = { chat_channel_id: 123 };
+
+      await render(<template><ResponsiveLivestreamChatIcon /></template>);
+
+      assert
+        .dom(".livestream-header-icon")
+        .doesNotExist("Icon hidden on desktop");
+    });
+
+    test("it hides the icon when topic has no chat channel", async function (assert) {
+      const capabilities = this.owner.lookup("service:capabilities");
+      const topicController = this.owner.lookup("controller:topic");
+
+      capabilities.viewport = { lg: false };
+
+      topicController.model = { chat_channel_id: null };
+
+      await render(<template><ResponsiveLivestreamChatIcon /></template>);
+
+      assert
+        .dom(".livestream-header-icon")
+        .doesNotExist("Icon hidden when no chat channel");
+    });
+  }
+);


### PR DESCRIPTION
Follow-up to 478f06a135730a3fc1e20cb9657cf7e636ae90fe

The previous change caused the header button to appear when it shouldn't — this ensures it's a livestream topic. I've also added some related tests. 