### PR TITLE
DEV: Rename settings in preparation for moving to core

### DIFF
--- a/assets/javascripts/discourse/components/mobile-livestream-chat-icon.gjs
+++ b/assets/javascripts/discourse/components/mobile-livestream-chat-icon.gjs
@@ -11,7 +11,7 @@ export default class MobileLivestreamChatIcon extends Component {
 
   @action
   openLivestreamChat() {
-    if (this.siteSettings.enable_modal_chat_on_mobile) {
+    if (this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile) {
       this.modal.show(MobileEmbeddableChatModal);
     } else {
       this.embeddableChat.toggleChatVisibility();

--- a/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
+++ b/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
@@ -11,7 +11,7 @@ export default class EmbedableChatChannelConnector extends Component {
 
   get shouldRender() {
     const mobileViewport =
-      !this.siteSettings.enable_modal_chat_on_mobile &&
+      !this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile &&
       !this.capabilities.viewport.lg;
 
     return this.embeddableChat.canRenderChatChannel(

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -54,7 +54,7 @@ function overrideChat(api, container) {
   api.onPageChange((url) => {
     const store = container.lookup("service:store");
     const topic = container.lookup("controller:topic");
-    const allowedPaths = siteSettings.embeddable_chat_allowed_paths.split("|");
+    const allowedPaths = siteSettings.discourse_livestream_embeddable_chat_allowed_paths.split("|");
 
     // non livestream topics
     if (

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -54,7 +54,10 @@ function overrideChat(api, container) {
   api.onPageChange((url) => {
     const store = container.lookup("service:store");
     const topic = container.lookup("controller:topic");
-    const allowedPaths = siteSettings.discourse_livestream_embeddable_chat_allowed_paths.split("|");
+    const allowedPaths =
+      siteSettings.discourse_livestream_embeddable_chat_allowed_paths.split(
+        "|"
+      );
 
     // non livestream topics
     if (

--- a/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -22,7 +22,7 @@ export default class EmbeddableChat extends Chat {
       this.userCanChat
     ) {
       const allowedPaths =
-        this.siteSettings.embeddable_chat_allowed_paths.split("|");
+        this.siteSettings.discourse_livestream_embeddable_chat_allowed_paths.split("|");
       const withinPathsAllowed = allowedPaths.some(
         (path) =>
           this.router.currentURL.includes(path) ||
@@ -55,7 +55,7 @@ export default class EmbeddableChat extends Chat {
 
   get isMobileModal() {
     return (
-      this.siteSettings.enable_modal_chat_on_mobile && this.isMobileViewport
+      this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile && this.isMobileViewport
     );
   }
 

--- a/assets/javascripts/discourse/services/embeddable-chat.gjs
+++ b/assets/javascripts/discourse/services/embeddable-chat.gjs
@@ -22,7 +22,9 @@ export default class EmbeddableChat extends Chat {
       this.userCanChat
     ) {
       const allowedPaths =
-        this.siteSettings.discourse_livestream_embeddable_chat_allowed_paths.split("|");
+        this.siteSettings.discourse_livestream_embeddable_chat_allowed_paths.split(
+          "|"
+        );
       const withinPathsAllowed = allowedPaths.some(
         (path) =>
           this.router.currentURL.includes(path) ||
@@ -55,7 +57,8 @@ export default class EmbeddableChat extends Chat {
 
   get isMobileModal() {
     return (
-      this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile && this.isMobileViewport
+      this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile &&
+      this.isMobileViewport
     );
   }
 

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,4 +1,6 @@
 en:
   site_settings:
     discourse_livestream_enabled: "Enable Discourse Livestream"
-    livestream_chat_allowed_groups: "Only allowlisted groups can chat"
+    discourse_livestream_chat_allowed_groups: "Only allowlisted groups can chat"
+    discourse_livestream_embeddable_chat_allowed_paths: "Allowed paths for embeddable chat"
+    discourse_livestream_enable_modal_chat_on_mobile: "Enable modal chat on mobile"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,5 +13,3 @@ plugins:
     default: "11" # default group trust_level_1
     client: true
     type: group_list
-
-

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,14 +2,14 @@ plugins:
   discourse_livestream_enabled:
     default: false
     client: true
-  embeddable_chat_allowed_paths:
+  discourse_livestream_embeddable_chat_allowed_paths:
     type: list
     default: "/t"
     client: true
-  enable_modal_chat_on_mobile:
+  discourse_livestream_enable_modal_chat_on_mobile:
     default: true
     client: true
-  livestream_chat_allowed_groups:
+  discourse_livestream_chat_allowed_groups:
     default: "11" # default group trust_level_1
     client: true
     type: group_list

--- a/db/migrate/20260601060042_rename_site_settings_for_core_move.rb
+++ b/db/migrate/20260601060042_rename_site_settings_for_core_move.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class RenameSiteSettingsForCoreMove < ActiveRecord::Migration[8.0]
+  def up
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'discourse_livestream_embeddable_chat_allowed_paths'
+      WHERE name = 'embeddable_chat_allowed_paths'
+    SQL
+
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'discourse_livestream_enable_modal_chat_on_mobile'
+      WHERE name = 'enable_modal_chat_on_mobile'
+    SQL
+
+    execute <<~SQL
+      UPDATE site_settings
+      SET name = 'discourse_livestream_chat_allowed_groups'
+      WHERE name = 'livestream_chat_allowed_groups'
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/jobs/regular/recalculate_user_livestream_channel_memberships.rb
+++ b/jobs/regular/recalculate_user_livestream_channel_memberships.rb
@@ -45,8 +45,7 @@ module Jobs
     private
 
     def user_allowed_in_livestream_chat?(user)
-      allowed_groups = SiteSetting.livestream_chat_allowed_groups.split("|").map(&:to_i)
-      (allowed_groups & user.groups.ids).any?
+      user.in_any_groups?(SiteSetting.discourse_livestream_chat_allowed_groups_map)
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -63,8 +63,8 @@ after_initialize do
     channel = topic_chat_channel.chat_channel
     manager = Chat::ChannelMembershipManager.new(channel)
 
-    allowed_groups = SiteSetting.discourse_livestream_chat_allowed_groups.split("|").map(&:to_i)
-    user_allowed_in_chat = (allowed_groups & user.groups.ids).any?
+    user_allowed_in_chat =
+      user.in_any_groups?(SiteSetting.discourse_livestream_chat_allowed_groups_map)
 
     membership =
       if invitee.status == DiscoursePostEvent::Invitee.statuses[:going]
@@ -81,7 +81,7 @@ after_initialize do
   end
 
   on(:site_setting_changed) do |name, old_val, new_val|
-    if name == :livestream_chat_allowed_groups
+    if name == :discourse_livestream_chat_allowed_groups
       Jobs::RecalculateUserLivestreamChannelMemberships.new.execute
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -63,7 +63,7 @@ after_initialize do
     channel = topic_chat_channel.chat_channel
     manager = Chat::ChannelMembershipManager.new(channel)
 
-    allowed_groups = SiteSetting.livestream_chat_allowed_groups.split("|").map(&:to_i)
+    allowed_groups = SiteSetting.discourse_livestream_chat_allowed_groups.split("|").map(&:to_i)
     user_allowed_in_chat = (allowed_groups & user.groups.ids).any?
 
     membership =

--- a/spec/jobs/recalculate_user_Livestream_channel_memberships_spec.rb
+++ b/spec/jobs/recalculate_user_Livestream_channel_memberships_spec.rb
@@ -95,7 +95,9 @@ RSpec.describe Jobs::RecalculateUserLivestreamChannelMemberships do
   end
 
   describe "when user is not in the allow list" do
-    before { SiteSetting.livestream_chat_allowed_groups = "#{Group::AUTO_GROUPS[:trust_level_4]}" }
+    before do
+      SiteSetting.discourse_livestream_chat_allowed_groups = Group::AUTO_GROUPS[:trust_level_4].to_s
+    end
 
     it "unfollows all livestream channels" do
       run_job

--- a/spec/system/livestream_calendar_event_spec.rb
+++ b/spec/system/livestream_calendar_event_spec.rb
@@ -13,8 +13,8 @@ describe "Discourse Livestream - Topic Livestream with events - Authenticated" d
     SiteSetting.discourse_livestream_enabled = true
     SiteSetting.calendar_enabled = true
     SiteSetting.discourse_post_event_enabled = true
-    SiteSetting.discourse_post_event_allowed_on_groups = group.id
-    SiteSetting.livestream_chat_allowed_groups = "#{group.id}"
+    SiteSetting.discourse_post_event_allowed_on_groups = group.id.to_s
+    SiteSetting.discourse_livestream_chat_allowed_groups = group.id.to_s
     sign_in(current_user)
   end
 

--- a/spec/system/mobile_topic_livestream_authenticated_spec.rb
+++ b/spec/system/mobile_topic_livestream_authenticated_spec.rb
@@ -40,7 +40,7 @@ describe "Discourse Livestream - Topic Livestream - Mobile - Authenticated", mob
 
     context "when user in allowlisted group" do
       it "opens the chat channel and allows to chat after clicking the header icon" do
-        SiteSetting.livestream_chat_allowed_groups = "#{Group::AUTO_GROUPS[:admins]}"
+        SiteSetting.discourse_livestream_chat_allowed_groups = Group::AUTO_GROUPS[:admins].to_s
         topic_livestream.create_livestream_event_topic(composer, topic_page, livestream_tag)
 
         find(".going-button").click
@@ -53,8 +53,10 @@ describe "Discourse Livestream - Topic Livestream - Mobile - Authenticated", mob
     end
 
     context "when user not in allowlisted group" do
+      fab!(:group)
+
       it "opens the chat channel and allows to chat after clicking the header icon" do
-        SiteSetting.livestream_chat_allowed_groups = "200"
+        SiteSetting.discourse_livestream_chat_allowed_groups = group.id.to_s
         topic_livestream.create_livestream_event_topic(composer, topic_page, livestream_tag)
 
         find(".going-button").click

--- a/test/javascripts/channel-icon-test.gjs
+++ b/test/javascripts/channel-icon-test.gjs
@@ -18,8 +18,9 @@ module("Integration | Component | MobileLivestreamChatIcon", function (hooks) {
     const modalService = this.owner.lookup("service:modal");
     const showSpy = sinon.spy(modalService, "show");
 
-    this.owner.lookup("service:site-settings").discourse_livestream_enable_modal_chat_on_mobile =
-      true;
+    this.owner.lookup(
+      "service:site-settings"
+    ).discourse_livestream_enable_modal_chat_on_mobile = true;
 
     await render(<template><MobileLivestreamChatIcon /></template>);
     await click("button");
@@ -28,8 +29,9 @@ module("Integration | Component | MobileLivestreamChatIcon", function (hooks) {
   });
 
   test("toggles chat visibility if discourse_livestream_enable_modal_chat_on_mobile is false", async function (assert) {
-    this.owner.lookup("service:site-settings").discourse_livestream_enable_modal_chat_on_mobile =
-      false;
+    this.owner.lookup(
+      "service:site-settings"
+    ).discourse_livestream_enable_modal_chat_on_mobile = false;
     const embeddableChatService = this.owner.lookup("service:embeddable-chat");
 
     assert.false(

--- a/test/javascripts/channel-icon-test.gjs
+++ b/test/javascripts/channel-icon-test.gjs
@@ -14,11 +14,11 @@ module("Integration | Component | MobileLivestreamChatIcon", function (hooks) {
     assert.dom("button").hasClass("icon");
   });
 
-  test("opens the chat modal if enable_modal_chat_on_mobile is true", async function (assert) {
+  test("opens the chat modal if discourse_livestream_enable_modal_chat_on_mobile is true", async function (assert) {
     const modalService = this.owner.lookup("service:modal");
     const showSpy = sinon.spy(modalService, "show");
 
-    this.owner.lookup("service:site-settings").enable_modal_chat_on_mobile =
+    this.owner.lookup("service:site-settings").discourse_livestream_enable_modal_chat_on_mobile =
       true;
 
     await render(<template><MobileLivestreamChatIcon /></template>);
@@ -27,8 +27,8 @@ module("Integration | Component | MobileLivestreamChatIcon", function (hooks) {
     assert.true(showSpy.calledWith(MobileEmbeddableChatModal));
   });
 
-  test("toggles chat visibility if enable_modal_chat_on_mobile is false", async function (assert) {
-    this.owner.lookup("service:site-settings").enable_modal_chat_on_mobile =
+  test("toggles chat visibility if discourse_livestream_enable_modal_chat_on_mobile is false", async function (assert) {
+    this.owner.lookup("service:site-settings").discourse_livestream_enable_modal_chat_on_mobile =
       false;
     const embeddableChatService = this.owner.lookup("service:embeddable-chat");
 


### PR DESCRIPTION
We are incorporating this plugin into the core discourse-calendar
plugin, and we don't want the setting names to conflict.

Rename all of them so we can reuse the old setting names or
come up with new ones in calendar.

discourse_livestream_enabled will remain...in core we will
probably call this livestream_enabled
