### PR TITLE
DEV: Make plugin a noop when discourse-calendar livestream enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Discourse Livestream
 
+> [!WARNING]
+> **⚠️ Deprecation Notice**
+>
+> **The Discourse Livestream plugin is deprecated, all functionality has been moved to the core [Discourse Calendar plugin](https://github.com/discourse/discourse-calendar).**
+
 **Plugin Summary**
 
 This plugin allows you to embed a live stream from a variety of sources inside a Discourse community.

--- a/jobs/regular/recalculate_user_livestream_channel_memberships.rb
+++ b/jobs/regular/recalculate_user_livestream_channel_memberships.rb
@@ -3,8 +3,10 @@
 module Jobs
   class RecalculateUserLivestreamChannelMemberships < ::Jobs::Base
     def execute
+      # Note that livestream_enabled is a discourse-calendar setting that makes
+      # this whole plugin a noop.
       if !SiteSetting.calendar_enabled || !SiteSetting.discourse_post_event_enabled ||
-           !SiteSetting.discourse_livestream_enabled
+           !SiteSetting.discourse_livestream_enabled || SiteSetting.livestream_enabled
         return
       end
 

--- a/jobs/regular/recalculate_user_livestream_channel_memberships.rb
+++ b/jobs/regular/recalculate_user_livestream_channel_memberships.rb
@@ -6,7 +6,8 @@ module Jobs
       # Note that livestream_enabled is a discourse-calendar setting that makes
       # this whole plugin a noop.
       if !SiteSetting.calendar_enabled || !SiteSetting.discourse_post_event_enabled ||
-           !SiteSetting.discourse_livestream_enabled || SiteSetting.livestream_enabled
+           !SiteSetting.discourse_livestream_enabled ||
+           (SiteSetting.respond_to?(:livestream_enabled) && !SiteSetting.livestream_enabled)
         return
       end
 

--- a/jobs/regular/recalculate_user_livestream_channel_memberships.rb
+++ b/jobs/regular/recalculate_user_livestream_channel_memberships.rb
@@ -7,7 +7,7 @@ module Jobs
       # this whole plugin a noop.
       if !SiteSetting.calendar_enabled || !SiteSetting.discourse_post_event_enabled ||
            !SiteSetting.discourse_livestream_enabled ||
-           (SiteSetting.respond_to?(:livestream_enabled) && !SiteSetting.livestream_enabled)
+           (SiteSetting.respond_to?(:livestream_enabled) && SiteSetting.livestream_enabled)
         return
       end
 

--- a/lib/discourse_livestream/handle_topic_chat_channel_creation.rb
+++ b/lib/discourse_livestream/handle_topic_chat_channel_creation.rb
@@ -4,7 +4,7 @@ module DiscourseLivestream
   def self.handle_topic_chat_channel_creation(topic)
     # Note that livestream_enabled is a discourse-calendar setting that makes
     # this whole plugin a noop.
-    return if SiteSetting.respond_to?(:livestream_enabled) && !SiteSetting.livestream_enabled
+    return if SiteSetting.respond_to?(:livestream_enabled) && SiteSetting.livestream_enabled
     return if topic.category.blank?
     return if DiscourseLivestream::TopicChatChannel.exists?(topic_id: topic.id)
     return if topic.tags.blank? || topic.tags.none? { |tag| tag.name == "livestream" }

--- a/lib/discourse_livestream/handle_topic_chat_channel_creation.rb
+++ b/lib/discourse_livestream/handle_topic_chat_channel_creation.rb
@@ -2,6 +2,9 @@
 
 module DiscourseLivestream
   def self.handle_topic_chat_channel_creation(topic)
+    # Note that livestream_enabled is a discourse-calendar setting that makes
+    # this whole plugin a noop.
+    return if SiteSetting.livestream_enabled
     return if topic.category.blank?
     return if DiscourseLivestream::TopicChatChannel.exists?(topic_id: topic.id)
     return if topic.tags.blank? || topic.tags.none? { |tag| tag.name == "livestream" }

--- a/lib/discourse_livestream/handle_topic_chat_channel_creation.rb
+++ b/lib/discourse_livestream/handle_topic_chat_channel_creation.rb
@@ -4,7 +4,7 @@ module DiscourseLivestream
   def self.handle_topic_chat_channel_creation(topic)
     # Note that livestream_enabled is a discourse-calendar setting that makes
     # this whole plugin a noop.
-    return if SiteSetting.livestream_enabled
+    return if SiteSetting.respond_to?(:livestream_enabled) && !SiteSetting.livestream_enabled
     return if topic.category.blank?
     return if DiscourseLivestream::TopicChatChannel.exists?(topic_id: topic.id)
     return if topic.tags.blank? || topic.tags.none? { |tag| tag.name == "livestream" }

--- a/plugin.rb
+++ b/plugin.rb
@@ -33,56 +33,60 @@ after_initialize do
   end
 
   reloadable_patch do
-    Topic.prepend DiscourseLivestream::TopicExtension
-    Chat::Channel.prepend DiscourseLivestream::ChatChannelExtension
+    # If the discourse-calendar livestream functionality is enabled,
+    # this plugin is a noop.
+    if !SiteSetting.livestream_enabled
+      Topic.prepend DiscourseLivestream::TopicExtension
+      Chat::Channel.prepend DiscourseLivestream::ChatChannelExtension
 
-    add_to_serializer(:topic_view, :chat_channel_id) do
-      return nil if object.topic.topic_chat_channel.blank?
-      object.topic.topic_chat_channel.chat_channel_id
-    end
-
-    on(:post_edited) do |post, _, _|
-      DiscourseLivestream.handle_topic_chat_channel_creation(post.topic)
-    end
-    on(:topic_created) do |topic, _, _|
-      DiscourseLivestream.handle_topic_chat_channel_creation(topic)
-    end
-    on(:chat_channel_trashed) do |channel, user|
-      # If the chat channel is deleted, delete the related TopicChatChannel record
-      DiscourseLivestream::TopicChatChannel.where(chat_channel_id: channel.id).destroy_all
-    end
-  end
-
-  on(:discourse_calendar_post_event_invitee_status_changed) do |invitee|
-    topic = invitee.event.post.topic
-    topic_chat_channel = topic.topic_chat_channel
-
-    next if !topic_chat_channel
-
-    user = User.find(invitee.user_id)
-    channel = topic_chat_channel.chat_channel
-    manager = Chat::ChannelMembershipManager.new(channel)
-
-    user_allowed_in_chat =
-      user.in_any_groups?(SiteSetting.discourse_livestream_chat_allowed_groups_map)
-
-    membership =
-      if invitee.status == DiscoursePostEvent::Invitee.statuses[:going]
-        user_allowed_in_chat ? manager.follow(user) : manager.unfollow(user)
-      else
-        manager.unfollow(user)
+      add_to_serializer(:topic_view, :chat_channel_id) do
+        return nil if object.topic.topic_chat_channel.blank?
+        object.topic.topic_chat_channel.chat_channel_id
       end
 
-    ::MessageBus.publish "discourse_livestream_update_livestream_chat_status",
-                         Chat::UserChannelMembershipSerializer.new(
-                           membership,
-                           scope: Guardian.new(user),
-                         ).to_json
-  end
+      on(:post_edited) do |post, _, _|
+        DiscourseLivestream.handle_topic_chat_channel_creation(post.topic)
+      end
+      on(:topic_created) do |topic, _, _|
+        DiscourseLivestream.handle_topic_chat_channel_creation(topic)
+      end
+      on(:chat_channel_trashed) do |channel, user|
+        # If the chat channel is deleted, delete the related TopicChatChannel record
+        DiscourseLivestream::TopicChatChannel.where(chat_channel_id: channel.id).destroy_all
+      end
 
-  on(:site_setting_changed) do |name, old_val, new_val|
-    if name == :discourse_livestream_chat_allowed_groups
-      Jobs::RecalculateUserLivestreamChannelMemberships.new.execute
+      on(:discourse_calendar_post_event_invitee_status_changed) do |invitee|
+        topic = invitee.event.post.topic
+        topic_chat_channel = topic.topic_chat_channel
+
+        next if !topic_chat_channel
+
+        user = User.find(invitee.user_id)
+        channel = topic_chat_channel.chat_channel
+        manager = Chat::ChannelMembershipManager.new(channel)
+
+        user_allowed_in_chat =
+          user.in_any_groups?(SiteSetting.discourse_livestream_chat_allowed_groups_map)
+
+        membership =
+          if invitee.status == DiscoursePostEvent::Invitee.statuses[:going]
+            user_allowed_in_chat ? manager.follow(user) : manager.unfollow(user)
+          else
+            manager.unfollow(user)
+          end
+
+        ::MessageBus.publish "discourse_livestream_update_livestream_chat_status",
+                             Chat::UserChannelMembershipSerializer.new(
+                               membership,
+                               scope: Guardian.new(user),
+                             ).to_json
+      end
+
+      on(:site_setting_changed) do |name, old_val, new_val|
+        if name == :discourse_livestream_chat_allowed_groups
+          Jobs::RecalculateUserLivestreamChannelMemberships.new.execute
+        end
+      end
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,7 +35,7 @@ after_initialize do
   reloadable_patch do
     # If the discourse-calendar livestream functionality is enabled,
     # this plugin is a noop.
-    if !SiteSetting.livestream_enabled
+    if SiteSetting.respond_to?(:livestream_enabled) && !SiteSetting.livestream_enabled
       Topic.prepend DiscourseLivestream::TopicExtension
       Chat::Channel.prepend DiscourseLivestream::ChatChannelExtension
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -35,7 +35,7 @@ after_initialize do
   reloadable_patch do
     # If the discourse-calendar livestream functionality is enabled,
     # this plugin is a noop.
-    if SiteSetting.respond_to?(:livestream_enabled) && !SiteSetting.livestream_enabled
+    if !(SiteSetting.respond_to?(:livestream_enabled) && SiteSetting.livestream_enabled)
       Topic.prepend DiscourseLivestream::TopicExtension
       Chat::Channel.prepend DiscourseLivestream::ChatChannelExtension
 

--- a/spec/fabricators/post_event_invitee_fabricator.rb
+++ b/spec/fabricators/post_event_invitee_fabricator.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-Fabricator(:post_event_invitee, from: "DiscoursePostEvent::Invitee") do
+Fabricator(:discourse_livestream_post_event_invitee, from: "DiscoursePostEvent::Invitee") do
   event
   user
   status { |attrs| attrs[:status] || nil }

--- a/spec/fabricators/topic_chat_channel_fabricator.rb
+++ b/spec/fabricators/topic_chat_channel_fabricator.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
-Fabricator(:topic_chat_channel, from: "DiscourseLivestream::TopicChatChannel") do
+Fabricator(
+  :discourse_livestream_topic_chat_channel,
+  from: "DiscourseLivestream::TopicChatChannel",
+) do
   topic
   chat_channel
 end

--- a/spec/jobs/recalculate_user_Livestream_channel_memberships_spec.rb
+++ b/spec/jobs/recalculate_user_Livestream_channel_memberships_spec.rb
@@ -18,10 +18,18 @@ RSpec.describe Jobs::RecalculateUserLivestreamChannelMemberships do
   fab!(:topic2) { Fabricate(:topic, user: user) }
 
   fab!(:topic_chat_channel1) do
-    Fabricate(:topic_chat_channel, topic: topic1, chat_channel: livestream_channel1)
+    Fabricate(
+      :discourse_livestream_topic_chat_channel,
+      topic: topic1,
+      chat_channel: livestream_channel1,
+    )
   end
   fab!(:topic_chat_channel2) do
-    Fabricate(:topic_chat_channel, topic: topic2, chat_channel: livestream_channel2)
+    Fabricate(
+      :discourse_livestream_topic_chat_channel,
+      topic: topic2,
+      chat_channel: livestream_channel2,
+    )
   end
 
   fab!(:first_post1) { Fabricate(:post, topic: topic1) }
@@ -73,7 +81,7 @@ RSpec.describe Jobs::RecalculateUserLivestreamChannelMemberships do
 
   fab!(:post_event_invitee1) do
     Fabricate(
-      :post_event_invitee,
+      :discourse_livestream_post_event_invitee,
       event: event1,
       user: user,
       status: DiscoursePostEvent::Invitee.statuses[:going],
@@ -82,7 +90,7 @@ RSpec.describe Jobs::RecalculateUserLivestreamChannelMemberships do
 
   fab!(:post_event_invitee2) do
     Fabricate(
-      :post_event_invitee,
+      :discourse_livestream_post_event_invitee,
       event: event2,
       user: user,
       status: DiscoursePostEvent::Invitee.statuses[:going],


### PR DESCRIPTION
We are moving this plugin code into core in https://github.com/discourse/discourse/pull/40466
If the core discourse-calendar setting livestream_enabled is true,
then this whole plugin should become a noop.

Also adds a problem check for admins and updates README.md to indicate
that this plugin is not needed if the core setting is enabled.
