### PR TITLE
DEV: Improve compatability with core calendar discourse-livestream plugin

### DIFF
--- a/assets/javascripts/discourse/components/embeddable-chat-channel.gjs
+++ b/assets/javascripts/discourse/components/embeddable-chat-channel.gjs
@@ -10,7 +10,7 @@ import toggleClass from "../modifiers/toggle-class";
 
 export default class EmbedableChatChannel extends Component {
   @service chatChannelsManager;
-  @service embeddableChat;
+  @service livestreamEmbeddableChat;
   @service messageBus;
 
   @tracked activeChannel;
@@ -50,16 +50,19 @@ export default class EmbedableChatChannel extends Component {
   <template>
     <div
       id="custom-chat-container"
-      {{toggleClass this.embeddableChat.isMobileChatVisible "mobile"}}
-      class={{unless this.embeddableChat.isMobileModal "no-modal-mobile"}}
+      {{toggleClass this.livestreamEmbeddableChat.isMobileChatVisible "mobile"}}
+      class={{unless
+        this.livestreamEmbeddableChat.isMobileModal
+        "no-modal-mobile"
+      }}
       {{this.updateChannel}}
     >
-      {{#unless this.embeddableChat.isMobileModal}}
+      {{#unless this.livestreamEmbeddableChat.isMobileModal}}
         <div class="c-navbar-container livestream-chat-close">
 
           <DButton
             @icon="xmark"
-            @action={{this.embeddableChat.toggleChatVisibility}}
+            @action={{this.livestreamEmbeddableChat.toggleChatVisibility}}
             @title="chat.close"
             class="btn-transparent no-text c-navbar__close-drawer-button"
           />

--- a/assets/javascripts/discourse/components/join-channel-message.gjs
+++ b/assets/javascripts/discourse/components/join-channel-message.gjs
@@ -6,13 +6,14 @@ import concatClass from "discourse/helpers/concat-class";
 import { i18n } from "discourse-i18n";
 
 export default class JoinChannelMessage extends Component {
-  @service embeddableChat;
+  @service livestreamEmbeddableChat;
   @controller("topic") topicController;
 
   get shouldRenderJoinText() {
     const topic = this.topicController?.model;
     return (
-      topic?.chat_channel_id && this.embeddableChat.topicHasLivestreamTag(topic)
+      topic?.chat_channel_id &&
+      this.livestreamEmbeddableChat.topicHasLivestreamTag(topic)
     );
   }
 

--- a/assets/javascripts/discourse/components/mobile-livestream-chat-icon.gjs
+++ b/assets/javascripts/discourse/components/mobile-livestream-chat-icon.gjs
@@ -6,7 +6,7 @@ import MobileEmbeddableChatModal from "./modal/mobile-embeddable-chat-modal";
 
 export default class MobileLivestreamChatIcon extends Component {
   @service modal;
-  @service embeddableChat;
+  @service livestreamEmbeddableChat;
   @service siteSettings;
 
   @action
@@ -14,7 +14,7 @@ export default class MobileLivestreamChatIcon extends Component {
     if (this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile) {
       this.modal.show(MobileEmbeddableChatModal);
     } else {
-      this.embeddableChat.toggleChatVisibility();
+      this.livestreamEmbeddableChat.toggleChatVisibility();
     }
   }
 

--- a/assets/javascripts/discourse/components/modal/mobile-embeddable-chat-modal.gjs
+++ b/assets/javascripts/discourse/components/modal/mobile-embeddable-chat-modal.gjs
@@ -6,7 +6,7 @@ import DModal from "discourse/components/d-modal";
 import EmbeddableChatChannel from "../embeddable-chat-channel";
 
 export default class MobileEmbeddableChatModal extends Component {
-  @service embeddableChat;
+  @service livestreamEmbeddableChat;
   @service capabilities;
   @controller("topic") topicController;
 
@@ -17,7 +17,10 @@ export default class MobileEmbeddableChatModal extends Component {
   };
 
   get shouldRender() {
-    return this.embeddableChat.canRenderChatChannel(this.topicController, true);
+    return this.livestreamEmbeddableChat.canRenderChatChannel(
+      this.topicController,
+      true
+    );
   }
 
   <template>
@@ -30,7 +33,7 @@ export default class MobileEmbeddableChatModal extends Component {
       <:body>
         {{#if this.shouldRender}}
           <EmbeddableChatChannel
-            @chatChannelId={{this.embeddableChat.chatChannelId}}
+            @chatChannelId={{this.livestreamEmbeddableChat.chatChannelId}}
           />
         {{/if}}
       </:body>

--- a/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
+++ b/assets/javascripts/discourse/connectors/before-main-outlet/embeddable-chat-channel-connector.gjs
@@ -4,7 +4,7 @@ import { service } from "@ember/service";
 import EmbeddableChatChannel from "../../components/embeddable-chat-channel";
 
 export default class EmbedableChatChannelConnector extends Component {
-  @service embeddableChat;
+  @service livestreamEmbeddableChat;
   @service siteSettings;
   @service capabilities;
   @controller("topic") topicController;
@@ -14,7 +14,13 @@ export default class EmbedableChatChannelConnector extends Component {
       !this.siteSettings.discourse_livestream_enable_modal_chat_on_mobile &&
       !this.capabilities.viewport.lg;
 
-    return this.embeddableChat.canRenderChatChannel(
+    // If the core discourse-calendar livestream is enabled, this
+    // plugin should be a noop.
+    if (this.siteSettings.livestream_enabled) {
+      return false;
+    }
+
+    return this.livestreamEmbeddableChat.canRenderChatChannel(
       this.topicController,
       mobileViewport
     );
@@ -23,7 +29,7 @@ export default class EmbedableChatChannelConnector extends Component {
   <template>
     {{#if this.shouldRender}}
       <EmbeddableChatChannel
-        @chatChannelId={{this.embeddableChat.chatChannelId}}
+        @chatChannelId={{this.livestreamEmbeddableChat.chatChannelId}}
       />
     {{/if}}
   </template>

--- a/assets/javascripts/discourse/initializers/chat-overrides.js
+++ b/assets/javascripts/discourse/initializers/chat-overrides.js
@@ -33,6 +33,12 @@ function overrideChat(api, container) {
     return;
   }
 
+  // If the core discourse-calendar livestream is enabled, this
+  // plugin should be a noop.
+  if (siteSettings.livestream_enabled) {
+    return;
+  }
+
   const events = [
     "calendar:update-invitee-status",
     "calendar:create-invitee-status",

--- a/assets/javascripts/discourse/initializers/join-channel-message.js
+++ b/assets/javascripts/discourse/initializers/join-channel-message.js
@@ -1,0 +1,19 @@
+import { withPluginApi } from "discourse/lib/plugin-api";
+import JoinChannelMessage from "../components/join-channel-message";
+
+export default {
+  name: "discourse-livestream-join-channel-message",
+  initialize() {
+    withPluginApi((api) => {
+      const siteSettings = api.container.lookup("service:site-settings");
+
+      // If the core discourse-calendar livestream is enabled, this
+      // plugin should be a noop.
+      if (siteSettings.livestream_enabled) {
+        return;
+      }
+
+      api.renderInOutlet("chat-join-channel-button", JoinChannelMessage);
+    });
+  },
+};

--- a/assets/javascripts/discourse/services/livestream-embeddable-chat.gjs
+++ b/assets/javascripts/discourse/services/livestream-embeddable-chat.gjs
@@ -5,7 +5,7 @@ import Chat from "discourse/plugins/chat/discourse/services/chat";
 
 export const LIVESTREAM_TAG_NAME = "livestream";
 
-export default class EmbeddableChat extends Chat {
+export default class LivestreamEmbeddableChat extends Chat {
   @service siteSettings;
   @service router;
   @service currentUser;
@@ -17,6 +17,7 @@ export default class EmbeddableChat extends Chat {
     this.topicController = topicController;
     if (
       this.isMobileViewport === mobileViewAllowed &&
+      this.siteSettings.discourse_livestream_enabled &&
       this.siteSettings.chat_enabled &&
       this.currentUser &&
       this.userCanChat

--- a/test/javascripts/channel-icon-test.gjs
+++ b/test/javascripts/channel-icon-test.gjs
@@ -32,10 +32,12 @@ module("Integration | Component | MobileLivestreamChatIcon", function (hooks) {
     this.owner.lookup(
       "service:site-settings"
     ).discourse_livestream_enable_modal_chat_on_mobile = false;
-    const embeddableChatService = this.owner.lookup("service:embeddable-chat");
+    const livestreamEmbeddableChatService = this.owner.lookup(
+      "service:livestream-embeddable-chat"
+    );
 
     assert.false(
-      embeddableChatService.isMobileChatVisible,
+      livestreamEmbeddableChatService.isMobileChatVisible,
       "Initial state isMobileChatVisible is false"
     );
 
@@ -43,14 +45,14 @@ module("Integration | Component | MobileLivestreamChatIcon", function (hooks) {
     await click("button");
 
     assert.true(
-      embeddableChatService.isMobileChatVisible,
+      livestreamEmbeddableChatService.isMobileChatVisible,
       "isMobileChatVisible is true after clicking button"
     );
 
     await click("button");
 
     assert.false(
-      embeddableChatService.isMobileChatVisible,
+      livestreamEmbeddableChatService.isMobileChatVisible,
       "isMobileChatVisible is false after clicking button again"
     );
   });


### PR DESCRIPTION
* Move JoinChannelMessage to initializer
  * We need to be able to not render this if core's
livestream_enabled is on, so we can't use the connector
path like we were before.
* Change embeddedChat service to livestreamEmbeddedChat
   to avoid service name conflicts with core
* Add more siteSettings.livestream_enabled checks to make this
   plugin a NOOP
